### PR TITLE
Bumped dependencies, added superagent

### DIFF
--- a/public_html/propbrowse/package.json
+++ b/public_html/propbrowse/package.json
@@ -21,9 +21,10 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
+    "superagent": "^5.1.0",
     "vue-loader": "^15.0.9",
     "vue-template-compiler": "^2.5.16",
-    "webpack": "^4.8.1",
-    "webpack-cli": "^2.1.3"
+    "webpack": "^4.39.3",
+    "webpack-cli": "^3.3.7"
   }
 }


### PR DESCRIPTION
Running `npm install` or `yarn` on the current code in `propbrowse` causes a known error https://github.com/webpack/webpack/issues/8082

I bumped both webpack and webpack-cli to the latest, and added superagent as an explicit requirement (wouldn't build without it)