### PR TITLE
Use kbd elements for Depictor's keyboard shortcut instructions

### DIFF
--- a/public_html/common/_common.scss
+++ b/public_html/common/_common.scss
@@ -25,6 +25,14 @@ a {
     text-decoration: none;
 }
 
+kbd {
+    border: 1px solid #999;
+    border-radius: 3px;
+    padding: 0.1em 0.3em;
+    background-color: #eee;
+    box-shadow: 1px 1px black;
+}
+
 .container {
     min-height: 100vh;
     display: flex;

--- a/public_html/depictor/js/components/screen-game.vue
+++ b/public_html/depictor/js/components/screen-game.vue
@@ -260,7 +260,7 @@
                 </small>
 
                 <span>
-                    {{$t("keyboard_shortcuts")}}: <b>(1)</b> {{$t("depicted")}}, <b>(2)</b> {{$t("skip")}}, <b>(3)</b> {{$t("not_depicted")}}, <b>(s)</b> {{$t("skip_item")}}
+                    {{$t("keyboard_shortcuts")}}: <kbd>1</kbd> → {{$t("depicted")}}; <kbd>2</kbd> → {{$t("skip")}}; <kbd>3</kbd> → {{$t("not_depicted")}}; <kbd>s</kbd> → {{$t("skip_item")}}.
                 </span>
 
                 <span v-show="!isPossibleChallenge">


### PR DESCRIPTION
Before:
![Screen Shot 2023-11-12 at 20 44 56](https://github.com/hay/wiki-tools/assets/478237/79baf26e-ea34-477e-bf58-04854670a019)


After:
![Screen Shot 2023-11-12 at 20 43 42](https://github.com/hay/wiki-tools/assets/478237/63043239-5fdd-48f3-9e70-378701dfbd09)
