### PR TITLE
Take into account the QID in hasFile checks

### DIFF
--- a/public_html/depictor/api/class-api.php
+++ b/public_html/depictor/api/class-api.php
@@ -27,10 +27,10 @@
             if ($action == "add-file") {
                 return $this->addFile($args);
             } else if ($action == "file-exists") {
-                $has = $this->hasFile($args["mid"]);
+                $has = $this->hasFile($args["mid"], $args["qid"]);
                 return ["status" => $has];
             } else if ($action == "files-exists") {
-                return $this->hasFiles($args["mids"] ?? []);
+                return $this->hasFiles($args["mids"] ?? [], $args["qid"] ?? '');
             } else if ($action == "item-exists") {
                 $has = $this->hasItem($args["qid"]);
                 return ["status" => $has];
@@ -109,7 +109,7 @@
             $this->assertChallengeId($args["challenge"] ?? null);
 
             // First check if maybe this pair of mid/qid is already in the db
-            if ($this->hasFile($args["mid"])) {
+            if ($this->hasFile($args["mid"], $args["qid"])) {
                 throw new Exception("Item already in database");
             }
 
@@ -183,17 +183,19 @@
             return $this->db->getChallenges();
         }
 
-        private function hasFile(string $mid):bool {
+        private function hasFile(string $mid, string $qid):bool {
             $this->assertItemid($mid);
-            return $this->db->fileExists($mid);
+            $this->assertItemid($qid);
+            return $this->db->fileExists($mid, $qid);
         }
 
-        private function hasFiles(array $mids):array {
+        private function hasFiles(array $mids, string $qid):array {
+            $this->assertItemid($qid);
             foreach ($mids as $mid) {
                 $this->assertItemid($mid);
             }
 
-            return $this->db->filesExist($mids, $this->userName);
+            return $this->db->filesExist($mids, $this->userName, $qid);
         }
 
         private function hasItem(string $qid):bool {

--- a/public_html/depictor/api/class-db.php
+++ b/public_html/depictor/api/class-db.php
@@ -97,10 +97,10 @@
             return $id;
         }
 
-        public function fileExists(string $mid):bool {
-            $sql = "select exists(select * from "  . TBL_DEPICTOR_FILES . " where mid = :mid and status != 'user-skipped')";
+        public function fileExists(string $mid, string $qid):bool {
+            $sql = "select exists(select * from "  . TBL_DEPICTOR_FILES . " where mid = :mid and qid = :qid and status != 'user-skipped')";
             $exists = ORM::for_table(TBL_DEPICTOR_FILES)
-                ->raw_query($sql, [ "mid" => $mid ])
+                ->raw_query($sql, [ "mid" => $mid, "qid" => $qid ])
                 ->find_array();
 
             // FIXME
@@ -113,11 +113,13 @@
         // 1) The MID is in the 'files' table and has the status of 'depicted' or 'not-depicted'
         // 2) The MID is in the 'files' table and has the status of 'user-skipped' AND the given
         //    userName is the same as the user in the table
-        public function filesExist(array $mids, string $userName):array {
+        // Consider only whether the files depict a given QID
+        public function filesExist(array $mids, string $userName, string $qid):array {
             // First do a query for all files with the given MIDS
             $files = ORM::for_table(TBL_DEPICTOR_FILES)
                 ->select(["mid", "status", "user"])
                 ->where_in("mid", $mids)
+                ->where("qid", $qid)
                 ->find_array();
 
             $exists = [];

--- a/public_html/depictor/js/api.js
+++ b/public_html/depictor/js/api.js
@@ -56,13 +56,13 @@ export default class Api {
         return req.id;
     }
 
-    async fileExists(mid) {
-        const req = await this.call('file-exists', { mid });
+    async fileExists(mid, qid) {
+        const req = await this.call('file-exists', { mid, qid });
         return req.status;
     }
 
-    async filesExist(mids) {
-        const req = await this.post('files-exists', { mids });
+    async filesExist(mids, qid) {
+        const req = await this.post('files-exists', { mids, qid });
         return req;
     }
 

--- a/public_html/depictor/js/store.js
+++ b/public_html/depictor/js/store.js
@@ -319,9 +319,9 @@ export default function createStore(opts) {
                 commit('itemDone', qid);
             },
 
-            async newFiles({ commit }, files) {
+            async newFiles({ commit }, { files, qid }) {
                 // Pass an API call and see if the items have already been done
-                const status = await api.filesExist(files.map(f => f.mid));
+                const status = await api.filesExist(files.map(f => f.mid), qid);
 
                 files = files.map((file) => {
                     file.done = status[file.mid];
@@ -434,7 +434,7 @@ export default function createStore(opts) {
                 }
 
                 commit('item', item);
-                await dispatch("newFiles", candidates);
+                await dispatch("newFiles", { files: candidates, qid: nextItem.qid });
                 commit('category', nextItem.category);
 
                 // All went well, let's get out of the loop


### PR DESCRIPTION
Suppose there's a group photo, eg. of a football team. Currently, if user selects that Person A is depicted there, this photo will not show up when processing Person B (which may also be depicted). Consequently, this behavior leads to suboptimal structured data being added to Commons – instead of depicting a few people, the images will end up as if they shown just one person.

As the database already stores what (MID, QID) pairs were done by users (so, not only the picture but also what's depicted), this patch aims to enable users to decide on images that were already done in another context. Therefore, cases like sports teams will be able to be properly tagged with structured data.